### PR TITLE
Basic template not found

### DIFF
--- a/docs/guides/templates.md
+++ b/docs/guides/templates.md
@@ -52,7 +52,7 @@ Some hosting providers maintain their own Remix templates. For more information,
 We also provide a [community-driven examples repository][examples], with each example showcasing different Remix features, patterns, tools, hosting providers, etc. You can use these in a similar manner to install the working example:
 
 ```shellscript nonumber
-npx create-remix@latest --template remix-run/examples/basic
+npx create-remix@latest --template remix-run/examples/tailwind
 ```
 
 ## Stacks


### PR DESCRIPTION
This command from the docs: https://remix.run/docs/en/main/guides/templates#third-party-templates

```
npx create-remix@latest --template remix-run/examples/basic
```

Throws an error because `/basic` doesnt exist

| Oh no! The path "basic" was not found in this GitHub repo.

So I replaced it with the simplest alternative I could find which was tailwind.

